### PR TITLE
Make notification popup hidden by default

### DIFF
--- a/client/src/components/Notifications/index.js
+++ b/client/src/components/Notifications/index.js
@@ -15,7 +15,7 @@ export default class Notifications extends Component {
     }
 
     state = {
-        showPopup: true,
+        showPopup: false,
     }
 
     togglePopup = (state = null) => {


### PR DESCRIPTION
In current code notification popup is visible by default. These changes will hide it until user click on bell.